### PR TITLE
Bypass csrf validation

### DIFF
--- a/webroot/js/script.js
+++ b/webroot/js/script.js
@@ -9,6 +9,9 @@ $(document).ready(function () {
             $('#startImport').css('display', 'none');
 
             $(this).ajaxSubmit({
+                "headers": {
+                    "X-CSRF-Token" : document.cookie.slice(10),
+                },
                 success: viewResponse
             });
 


### PR DESCRIPTION
set `X-CSRF-Token` value to csrf token in header to bypass csrf validation in versions from 2.2.0